### PR TITLE
Wagtail 7.2 maintenance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.9", "3.10", "3.11", "3.12"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         database: ["sqlite"]
 
     steps:
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.12"]
+        python: ["3.14"]
         database: ["postgres"]
 
     services:
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.12"]
+        python: ["3.14"]
         database: ["mysql"]
 
     services:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: 6.0.1
+    rev: 7.0.0
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 25.11.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
@@ -12,7 +12,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/jackdewinter/pymarkdown
-    rev: v0.9.32
+    rev: v0.9.33
     hooks:
       - id: pymarkdown
         args:
@@ -20,11 +20,11 @@ repos:
           - line-length
           - scan
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.20.0
+    rev: v3.21.1
     hooks:
     -   id: pyupgrade
   - repo: https://github.com/adamchainz/django-upgrade
-    rev: "1.27.0"  # replace with latest tag on GitHub
+    rev: "1.29.1"  # replace with latest tag on GitHub
     hooks:
     -   id: django-upgrade
-        args: [--target-version, "5.0"]   # Replace with Django version
+        args: [--target-version, "5.2"]   # Replace with Django version

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Add support for Python 3.13 and 3.14
+- Add support for Django 5.1 and 5.2
+- Add support for Wagtail 7.0, 7.1 and 7.2
+- Drop support for Python 3.9
+- Drop support for Django 5.0
+- Drop support for Wagtail 5.1 and 5.2
+- Update development dependencies
+
 ## [1.2.0] - 2024-07-13
 
 - Upgrade for Wagtail 6.1 & Django 5.0

--- a/README.md
+++ b/README.md
@@ -172,9 +172,9 @@ The field should be visibly hidden and not be available to receive any value fro
 
 Wagtail honey pot can be used in environments:
 
-- Python 3.9+
+- Python 3.10+
 - Django 4.2+
-- Wagtail 5.1+
+- Wagtail 6.3+
 
 ## Contributions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,20 +13,22 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Framework :: Django",
     "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Framework :: Wagtail",
-    "Framework :: Wagtail :: 5",
     "Framework :: Wagtail :: 6",
+    "Framework :: Wagtail :: 7",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies =[
-    "Wagtail>=5.1",
+    "Wagtail>=6.3",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,9 @@ dependencies =[
 
 [project.optional-dependencies]
 development = [
-    "black==24.4.2",
-    "flake8==7.1.0",
-    "isort==5.13.2",
+    "black==25.11.0",
+    "flake8==7.3.0",
+    "isort==7.0.0",
     "django-upgrade",
     "pyupgrade",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -4,16 +4,18 @@ usedevelop = True
 isolated_build = True
 
 envlist = 
-    py{39}-django{42}-wagtail{51,52}-sqlite
-    py{310,311,312}-django{50}-wagtail{52}-sqlite
-    py{312}-django{50}-wagtail{52}-{postgres,mysql}
+    py{310,311,312}-django42-wagtail{63,70,71,72}-sqlite
+    py{312,313}-django{51,52}-wagtail{70,71,72}-sqlite
+    py314-django52-wagtail72-sqlite
+    py314-django52-wagtail72-{postgres,mysql}
 
 [gh-actions]
 python =
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
+    3.14: py314
 
 [gh-actions:env]
 DATABASE = 
@@ -31,10 +33,13 @@ deps =
     coverage
 
     django42: Django>=4.2,<5.0
-    django50: Django>=5.0,<5.1
+    django51: Django>=5.1,<5.2
+    django52: Django>=5.2,<5.3
 
-    wagtail51: wagtail>=5.1,<5.2
-    wagtail52: wagtail>=5.2,<5.3
+    wagtail63: wagtail>=6.3,<6.4
+    wagtail70: wagtail>=7.0,<7.1
+    wagtail71: wagtail>=7.1,<7.2
+    wagtail72: wagtail>=7.2,<7.3
 
     postgres: psycopg2
     mysql: mysqlclient


### PR DESCRIPTION
This pull request updates the project's supported Python, Django, and Wagtail versions, dropping older versions and adding support for the latest releases. It also updates development dependencies and adjusts CI and test configurations accordingly.

**Platform and framework support changes:**

* Dropped support for Python 3.9, Django 5.0, and Wagtail 5.1/5.2; added support for Python 3.13/3.14, Django 5.1/5.2, and Wagtail 7.0/7.1/7.2 in `pyproject.toml`, `tox.ini`, `README.md`

**Continuous integration and testing updates:**

* Updated GitHub Actions workflow (`.github/workflows/test.yml`) to test against Python 3.10–3.14 and removed Python 3.9 from the matrix; updated database test combinations to use newer Python versions.
* Refactored `tox.ini` to align with new Python/Django/Wagtail support.

**Development dependencies:**

* Upgraded development tools (isort, black, pymarkdown, pyupgrade, django-upgrade) to their latest versions and updated Django target version for code upgrades.

**Documentation:**

* Updated `README.md` and `CHANGELOG` to reflect new platform and framework requirements and supported versions. 