### PR TITLE
Improve accessibility: add aria-hidden="true" to field

### DIFF
--- a/wagtail_honeypot/templates/tags/honeypot_fields.html
+++ b/wagtail_honeypot/templates/tags/honeypot_fields.html
@@ -1,4 +1,4 @@
 {% if enabled %}
-<input type="text" name="{{ honeypot_name_field }}" id="{{ honeypot_name_field }}" data-{{ honeypot_name_field }} tabindex="-1" autocomplete="off">
-<input type="hidden" name="{{ honeypot_time_field }}" id="{{ honeypot_time_field }}" data-{{ honeypot_time_field }} tabindex="-1" autocomplete="off" value="{{ time }}">
+<input type="text" name="{{ honeypot_name_field }}" id="{{ honeypot_name_field }}" data-{{ honeypot_name_field }} tabindex="-1" autocomplete="off" aria-hidden="true" >
+<input type="hidden" name="{{ honeypot_time_field }}" id="{{ honeypot_time_field }}" data-{{ honeypot_time_field }} tabindex="-1" autocomplete="off" value="{{ time }}" aria-hidden="true" >
 {% endif %}


### PR DESCRIPTION
Following an accessibility audit, it was recommended to add aria-hidden="true" to this field to exclude it from the accessibility tree. This change ensures that screen readers ignore the field, improving the overall accessibility of the page.

No functional changes are introduced.