### PR TITLE
Add GitHub Actions PyPI release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Validate release tag matches package version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          PACKAGE_VERSION="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+          EXPECTED_TAG="v${PACKAGE_VERSION}"
+
+          if [ "${RELEASE_TAG}" != "${EXPECTED_TAG}" ]; then
+            echo "Release tag ${RELEASE_TAG} does not match expected tag ${EXPECTED_TAG} derived from project version ${PACKAGE_VERSION}."
+            exit 1
+          fi
+
+      - name: Validate release commit is on main
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          RELEASE_SHA="$(git rev-list -n 1 "refs/tags/${RELEASE_TAG}")"
+
+          if ! git merge-base --is-ancestor "${RELEASE_SHA}" origin/main; then
+            echo "Release tag ${RELEASE_TAG} points to commit ${RELEASE_SHA}, which is not contained in origin/main."
+            exit 1
+          fi
+
+      - name: Build source distribution and wheel
+        run: uv build --sdist --wheel --out-dir dist
+
+      - name: Validate built artifacts
+        run: uvx twine check dist/*
+
+      - name: Upload built distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: pypi
+      url: https://pypi.org/project/wagtail-honeypot/
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download built distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   build:
@@ -70,11 +71,6 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     needs: build
-    environment:
-      name: pypi
-      url: https://pypi.org/project/wagtail-honeypot/
-    permissions:
-      id-token: write
 
     steps:
       - name: Download built distributions

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Update contributor and agent documentation for the new development workflow
 - Update the honeypot field documentation for the `aria-hidden="true"` accessibility attribute
 - Sync the Ruff pre-commit hook version with the locked Ruff release and correct the developer doc Wagtail baseline
+- Publish PyPI releases from GitHub Actions with trusted publishing and a protected `pypi` environment
 
 ## [1.2.1] - 2026-02-05
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 - Update contributor and agent documentation for the new development workflow
 - Update the honeypot field documentation for the `aria-hidden="true"` accessibility attribute
 - Sync the Ruff pre-commit hook version with the locked Ruff release and correct the developer doc Wagtail baseline
-- Publish PyPI releases from GitHub Actions with trusted publishing and a protected `pypi` environment
+- Publish PyPI releases from GitHub Actions with PyPI Trusted Publishing
 
 ## [1.2.1] - 2026-02-05
 

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -1,0 +1,84 @@
+# Releasing wagtail-honeypot
+
+This is the maintainer runbook for publishing package releases to PyPI via GitHub Actions.
+
+## Release Workflow
+
+- Workflow file: `.github/workflows/release.yml`
+- Trigger: GitHub Release event `published`
+- Authentication: PyPI Trusted Publisher (OIDC), no API token secret
+
+The release workflow:
+
+1. validates GitHub release tag (`vX.Y.Z` or pre-release like `vX.Y.Zrc1`) matches `project.version` in `pyproject.toml`
+2. validates the tagged commit is contained in `origin/main`
+3. builds `sdist` + `wheel` with `uv build`
+4. runs `twine check` on built artifacts
+5. publishes artifacts to PyPI using `pypa/gh-action-pypi-publish`
+
+## One-Time Setup (PyPI Trusted Publisher)
+
+In the PyPI project settings for `wagtail-honeypot`, add a Trusted Publisher with:
+
+- Owner or organization: `nm-packages`
+- Repository: `wagtail-honeypot`
+- Workflow: `release.yml`
+- Environment: unset (unless intentionally adding GitHub Environments later)
+
+The GitHub repository and workflow identity must match exactly, or publish will fail.
+
+## Maintainer Release Steps
+
+1. Keep `CHANGELOG` updated under `## Unreleased` for every merged PR landing on `main`.
+2. Update `version` in `pyproject.toml` to the intended release version.
+3. Convert the current `## Unreleased` notes in `CHANGELOG` into the new release entry, then leave a fresh `## Unreleased` placeholder for future work.
+4. Review user-facing docs and examples that intentionally describe the current release, and either:
+   - update them to the new version where exact release numbers are still useful, or
+   - remove brittle hardcoded release numbers when the docs work just as well without them.
+5. Merge the release-prep changes to `main`.
+6. Ensure normal CI on `main` is green (`Tests` workflow).
+7. Create a GitHub Release with a tag that matches the package version with `v` prefix.
+8. Use the `CHANGELOG` entry as the GitHub Release body.
+9. Publish the GitHub Release.
+10. Confirm `.github/workflows/release.yml` succeeds and the version appears on PyPI.
+
+For local sandbox/test command workflows before a release, use:
+
+- [developer.md](../developer.md) for canonical developer workflow and quickstart commands
+- [AGENTS.md](https://github.com/nm-packages/wagtail-honeypot/blob/release/AGENTS.md) for canonical contributor command/reference guidance
+
+## Changelog Maintenance
+
+- Add or update a `CHANGELOG` entry under `## Unreleased` in every PR.
+- During release prep, move or rewrite the `Unreleased` notes into the new versioned release section.
+- After release prep, keep an empty `## Unreleased` section in place for subsequent work.
+- During release prep, review any docs/examples that intentionally point at the current package release and avoid leaving stale version numbers in user-facing pages.
+
+Examples:
+
+- `pyproject.toml` version `1.3.0` => GitHub tag `v1.3.0`, release title `1.3.0` (or `Release 1.3.0`)
+- `pyproject.toml` version `1.4.0rc1` => GitHub tag `v1.4.0rc1`, release title `1.4.0rc1` (or `Release 1.4.0rc1`)
+
+## Local Preflight (Optional but Recommended)
+
+Run these before creating the GitHub Release:
+
+```bash
+uv build --sdist --wheel --out-dir /tmp/wagtail-honeypot-dist-check
+uvx twine check /tmp/wagtail-honeypot-dist-check/*
+```
+
+## Failure Modes and Troubleshooting
+
+- Tag/version mismatch:
+  - Symptom: workflow fails in "Validate release tag matches package version"
+  - Fix: align GitHub tag with `pyproject.toml` version and republish release
+- Tag commit not on main:
+  - Symptom: workflow fails in "Validate release commit is on main"
+  - Fix: retag a commit that is on `main`
+- Trusted Publisher identity mismatch:
+  - Symptom: PyPI publish step reports authorization/trust failure
+  - Fix: verify owner/repo/workflow values in PyPI Trusted Publisher settings
+- Duplicate version:
+  - Symptom: publish step fails because version already exists on PyPI
+  - Fix: bump `pyproject.toml` version and publish a new tag/release

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -70,6 +70,46 @@ make lint
 make format
 ```
 
+## Release process
+
+PyPI releases are published from GitHub Actions after a GitHub Release is published.
+
+Prepare the release from `main`, not `release`:
+
+```bash
+git switch main
+git pull origin main
+```
+
+Before creating the release:
+
+- Update `project.version` in `pyproject.toml`
+- Update `CHANGELOG` for the release
+- Ensure the commit you intend to release is on `main`
+
+Create and push the release tag using the `vX.Y.Z` format:
+
+```bash
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+Then publish the matching GitHub Release for that tag. The `Release` workflow will:
+
+- Verify the GitHub Release tag exactly matches `v{project.version}`
+- Verify the tagged commit is contained in `origin/main`
+- Build the sdist and wheel
+- Run `twine check`
+- Wait for approval on the GitHub `pypi` environment before uploading to PyPI
+
+Repository setup required for trusted publishing:
+
+- Add a GitHub environment named `pypi`
+- Protect that environment with the required approval rules for your release process
+- Register the PyPI trusted publisher for repository `nm-packages/wagtail-honeypot`, workflow `.github/workflows/release.yml`, and environment `pypi`
+
+After approving the `pypi` environment job, confirm both the source distribution and wheel appear on PyPI.
+
 ## Dependency management
 
 Use `uv` to change contributor dependencies and keep the lockfile in sync:

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -70,45 +70,7 @@ make lint
 make format
 ```
 
-## Release process
-
-PyPI releases are published from GitHub Actions after a GitHub Release is published.
-
-Prepare the release from `main`, not `release`:
-
-```bash
-git switch main
-git pull origin main
-```
-
-Before creating the release:
-
-- Update `project.version` in `pyproject.toml`
-- Update `CHANGELOG` for the release
-- Ensure the commit you intend to release is on `main`
-
-Create and push the release tag using the `vX.Y.Z` format:
-
-```bash
-git tag vX.Y.Z
-git push origin vX.Y.Z
-```
-
-Then publish the matching GitHub Release for that tag. The `Release` workflow will:
-
-- Verify the GitHub Release tag exactly matches `v{project.version}`
-- Verify the tagged commit is contained in `origin/main`
-- Build the sdist and wheel
-- Run `twine check`
-- Wait for approval on the GitHub `pypi` environment before uploading to PyPI
-
-Repository setup required for trusted publishing:
-
-- Add a GitHub environment named `pypi`
-- Protect that environment with the required approval rules for your release process
-- Register the PyPI trusted publisher for repository `nm-packages/wagtail-honeypot`, workflow `.github/workflows/release.yml`, and environment `pypi`
-
-After approving the `pypi` environment job, confirm both the source distribution and wheel appear on PyPI.
+See [Releasing wagtail-honeypot](contributing/releasing.md) for the maintainer release runbook.
 
 ## Dependency management
 


### PR DESCRIPTION
## Summary
- Add a GitHub Release-triggered workflow that builds the sdist and wheel, validates the tag against `project.version`, checks the tagged commit is on `main`, and publishes via trusted publishing.
- Document the release process in `docs/developer.md`, including the `vX.Y.Z` tag format and required `pypi` environment approval.
- Record the release automation change in `CHANGELOG`.

## Testing
- Not run (not requested)