### PR TITLE
Update branch workflow to main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,6 @@ name: Tests
 on:
   pull_request:
     branches:
-      - release
       - main
 
 concurrency:
@@ -11,34 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-sqlite-release:
-    if: github.base_ref == 'release'
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - python: "3.10"
-            toxenv: py310-django42-wagtail63-sqlite
-          - python: "3.14"
-            toxenv: py314-django60-wagtail73-sqlite
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Set up uv
-        id: setup-uv
-        uses: astral-sh/setup-uv@v8.1.0
-        with:
-          python-version: ${{ matrix.python }}
-          enable-cache: true
-
-      - name: Test with tox
-        id: test-with-tox
-        run: uvx --with tox-gh-actions tox -e ${{ matrix.toxenv }}
-
-  test-sqlite-main:
-    if: github.base_ref == 'main'
+  test-sqlite:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -63,7 +35,6 @@ jobs:
           DATABASE: ${{ matrix.database }}
 
   test-postgres:
-    if: github.base_ref == 'main'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -103,9 +74,7 @@ jobs:
           DB_PORT: 5432
           DATABASE: ${{ matrix.database }}
 
-
   test-mysql:
-    if: github.base_ref == 'main'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,12 +68,11 @@ This file guides coding agents working in this repository. Keep it operational a
 
 ## Branch Workflow
 
-- Treat `release` as the repository default branch.
-- Start all new work from `release`; it tracks the latest changes that are not yet released to PyPI.
-- Before making repo-tracked changes, create and switch to a new branch from `release`.
-- Do not make routine feature, fix, or documentation changes directly on `release` or `main` unless the task explicitly requires it.
-- Treat `main` as the release-preparation branch, not the starting point for routine feature or fix work.
-- Target routine merge requests at `release`; follow `docs/contributing/releasing.md` for release-prep work that lands on `main`.
+- Treat `main` as the repository default branch, pull request target, and release/tagging branch.
+- Start all new work from `main`.
+- Before making repo-tracked changes, create and switch to a new branch from `main`.
+- Do not make routine feature, fix, or documentation changes directly on `main` unless the task explicitly requires it.
+- Target routine pull requests at `main`.
 
 ## Change Boundaries
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Update contributor branch workflow guidance and PR CI to target `main`.
+
 ## [1.3.0] - 2026-04-21
 
 - Add Wagtail 7.3 testing coverage and Django 6.0 coverage for that compatibility line

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -45,7 +45,7 @@ The GitHub repository and workflow identity must match exactly, or publish will 
 For local sandbox/test command workflows before a release, use:
 
 - [developer.md](../developer.md) for canonical developer workflow and quickstart commands
-- [AGENTS.md](https://github.com/nm-packages/wagtail-honeypot/blob/release/AGENTS.md) for canonical contributor command/reference guidance
+- [AGENTS.md](https://github.com/nm-packages/wagtail-honeypot/blob/main/AGENTS.md) for canonical contributor command/reference guidance
 
 ## Changelog Maintenance
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dev = [
 [project.urls]
 Repository = "https://github.com/wagtail-packages/wagtail-honeypot"
 Issues = "https://github.com/wagtail-packages/wagtail-honeypot/issues"
-Changelog = "https://github.com/wagtail-packages/wagtail-honeypot/blob/release/CHANGELOG"
+Changelog = "https://github.com/wagtail-packages/wagtail-honeypot/blob/main/CHANGELOG"
 
 [tool.uv]
 default-groups = ["dev"]


### PR DESCRIPTION
## Summary
- Make `main` the default branch, routine PR target, and release/tagging branch in agent guidance.
- Remove the old `release` pull request target from CI and keep the full test matrix for PRs into `main`.
- Update branch-specific documentation links and the changelog URL to point at `main`.

## Verification
- Ran stale-reference search for old `release` branch workflow guidance.
- Parsed `.github/workflows/test.yml` as YAML.
- Ran `git diff --check`.